### PR TITLE
tautological general::general - per cargo clippy

### DIFF
--- a/src/bin/rush/general.rs
+++ b/src/bin/rush/general.rs
@@ -1,11 +1,11 @@
+extern crate libc;
+use std::fs::File;
+use std::os::unix::fs::OpenOptionsExt;
 
-pub mod general {
-
-  extern crate libc;
-  use std::fs::File;
-  use std::os::unix::fs::OpenOptionsExt;
-
-  pub fn check_dev_tty() {
-    let mut _tty = File::options().read(true).write(true).custom_flags(libc::O_NONBLOCK).open("/dev/tty");
-  }
+pub fn check_dev_tty() {
+    let mut _tty = File::options()
+        .read(true)
+        .write(true)
+        .custom_flags(libc::O_NONBLOCK)
+        .open("/dev/tty");
 }

--- a/src/bin/rush/main.rs
+++ b/src/bin/rush/main.rs
@@ -1,31 +1,29 @@
-
 mod general;
-use crate::general::general::*;
+use crate::general::*;
 
 use std::env;
 
-fn main(){
+fn main() {
+    let _argc = env::Args::len(&env::args());
 
-  let _argc=env::Args::len(&env::args());
-
-  loop {
-    let top_level = || -> Result<(), TopErrors> {
-      do_top_init()?;
-      Ok(())
-    };
-    if let Err(_err) = top_level() {
-      println!("Caught top error");
+    loop {
+        let top_level = || -> Result<(), TopErrors> {
+            do_top_init()?;
+            Ok(())
+        };
+        if let Err(_err) = top_level() {
+            println!("Caught top error");
+        }
     }
-  }
 }
 
 enum TopErrors {
-  TopError,
+    TopError,
 }
 
-fn do_top_init() -> Result<(), TopErrors>{
-  let _err=TopErrors::TopError;
-  println!("top_init");
-  check_dev_tty();
-  Ok(())
+fn do_top_init() -> Result<(), TopErrors> {
+    let _err = TopErrors::TopError;
+    println!("top_init");
+    check_dev_tty();
+    Ok(())
 }


### PR DESCRIPTION
Messing around with cargo clippy.
This change doesn't seem to break anything as top_init still runs fine.